### PR TITLE
fix: typedFormControl util now allow create disabled controls

### DIFF
--- a/projects/forms/src/lib/forms-typed.ts
+++ b/projects/forms/src/lib/forms-typed.ts
@@ -47,7 +47,7 @@ export interface TypedFormControl<K> extends FormControl, AbstractControl {
  * c.patchValue(1) //  COMPILE TIME! type error!
  */
 export function typedFormControl<T>(
-  v?: T,
+  v?: T | {value: T; disabled: boolean},
   validators?: ValidatorFn,
   asyncValidators?: AsyncValidatorFn
 ): TypedFormControl<T> {


### PR DESCRIPTION
Angular FormControl constructor allow alternative way to describe default value
In Angular FormControl constructor, boxed value object checked for containing both keys, value and disabled, for this reason they described as required