### PR TITLE
Keys/modelToView/viewToModel/TypedArray arguments

### DIFF
--- a/.github/workflows/release-forms-typed-rc.yml
+++ b/.github/workflows/release-forms-typed-rc.yml
@@ -1,8 +1,9 @@
-name: Release forms typed
+name: Release candidate - forms typed
 on:
   push:
     branches:
       - rc
+      - rc/**
 jobs:
   release:
     name: Release

--- a/.github/workflows/release-forms-typed-rc.yml
+++ b/.github/workflows/release-forms-typed-rc.yml
@@ -19,6 +19,8 @@ jobs:
           node-version: 12
       - name: Install dependencies
         run: npm ci
+      - name: Build example project (test)
+        run: npm run build:all
       - name: build lib
         run: npx ng build forms --prod
       - name: Release

--- a/.github/workflows/release-forms-typed.yml
+++ b/.github/workflows/release-forms-typed.yml
@@ -18,6 +18,8 @@ jobs:
           node-version: 12
       - name: Install dependencies
         run: npm ci
+      - name: Build example project (test step)
+        run: npm run build:all
       - name: build lib
         run: npx ng build forms --prod
       - name: Release

--- a/.github/workflows/release-show-form-control.yml
+++ b/.github/workflows/release-show-form-control.yml
@@ -1,4 +1,4 @@
-name: Release forms typed
+name: Release show form control
 on:
   push:
     branches:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,11 @@
     "typescript.tsdk": "node_modules\\typescript\\lib",
     "cSpell.words": [
         "Tidelift"
-    ]
+    ],
+    "workbench.colorCustomizations": {
+        "titleBar.activeBackground": "#eab353",
+        "titleBar.inactiveBackground": "#eab35399",
+        "titleBar.activeForeground": "#15202b",
+        "titleBar.inactiveForeground": "#15202b99"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "semantic-release": "semantic-release"
+    "semantic-release": "semantic-release",
+    "build:all": "ng build forms && ng build show-form-control && ng build"
   },
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,12 @@
     "branches": [
       "master",
       {
-        "name": "rc.",
+        "name": "rc",
+        "channel": "rc",
+        "prerelease": "rc"
+      },
+      {
+        "name": "rc/**",
         "channel": "rc",
         "prerelease": "rc"
       }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "branches": [
       "master",
       {
-        "name": "rc",
+        "name": "rc.",
         "channel": "rc",
         "prerelease": "rc"
       }

--- a/projects/forms/CHANGELOG.md
+++ b/projects/forms/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.9] - 2021-05-18
 ### Added
 -   allow `emitModelToViewChange?: boolean;` and `emitViewToModelChange?: boolean;` in the method options (e.g. `setValue`)
+### Fixed
+-   typedFormArray takes the item type first vs the array type first i.e. `typedFormArray<string>` vs `typedFormArray<string[], string>`
 
 ## [1.0.8] - 2020-12-12
 ### Fixed

--- a/projects/forms/CHANGELOG.md
+++ b/projects/forms/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.9] - 2021-05-18
+### Added
+-   allow `emitModelToViewChange?: boolean;` and `emitViewToModelChange?: boolean;` in the method options (e.g. `setValue`)
+
 ## [1.0.8] - 2020-12-12
 ### Fixed
 -   allow `AbstractControlOptions` in the `typedFormControl` helper function

--- a/projects/forms/README.md
+++ b/projects/forms/README.md
@@ -1,28 +1,31 @@
 # Forms Typed (ngx-forms-typed)
-This project aims at providing several tools for Angular Forms development, including: 
+This project aims at providing several tools for Angular Forms development, including:
  - types for strongly typing your `FormControl`s, `FormGroup`s and `FormArray`s based on a Model type
  - functions for instantiating the `TypedFormControl`, `TypedFormGroup` and `TypedFormArray` based on a Model type
- - a helper function that enumerates all controls in a form (group) 
+ - a helper function that enumerates all controls in a form (group)
      - calls methods on each of them
-     - attaches their validators to a parent form (group) 
+     - attaches their validators to a parent form (group)
      - attaches the touched/untouched behavior to a parent form (group)
- - a helper component that shows the form/group/control and allows for editing of the value emitted 
- 
+ - a helper component that shows the form/group/control and allows for editing of the value emitted
+
 ## Getting started
 
-1. `npm install --save-dev ngx-forms-typed` 
+1. `npm install --save-dev ngx-forms-typed`
 2. Create a model for your form (see [example](/src/app/person-contact/person-contact.model.ts))
 3. Inherit `ControlValueAccessorConnector` (see [example](/src/app/person-contact/person-contact.component.ts))
 4. Enjoy your type safety!
- 
+5. See **examples**:
+    - Shallow - https://stackblitz.com/edit/forms-typed-example-shallow?file=src/app/app.component.html
+    - Nested - https://stackblitz.com/edit/forms-typed-example-nested?file=src%2Fapp%2Fapp.component.html
+
 ## Features
 
-## Manually applying strong types to existing forms 
+## Manually applying strong types to existing forms
 ![Manually typed example - value - missing image](./assets/manually-typed-value.png)
 
 Example shows adding the strong type to an existing form control and its value is now **strong typed**!
 
-![Manually typed example - missing image](./assets/manually-typed.jpg) 
+![Manually typed example - missing image](./assets/manually-typed.jpg)
 The controls property is now **strong typed**!
 
 Note: The parameters for the `FormControl` are **not strong typed**. Notice we are passing the `t` as a FormControl and then are trying to access `email`. Hence the `typedFormGroup` function. See [below](#Using-the-helper-functions-to-strong-type-forms)
@@ -56,8 +59,8 @@ Multiple methods as params supported:
 ![For each control in - missing image](./assets/for-each-parent-child-interact.png)
 
 Here we want the validation of the child `Address` form to influence the parent `Person` form. That's the `addValidatorsTo()` method's job. We also want to make the child form touched if we call the parent form `touch()` method. That's the `markAsTouchedSimultaneouslyWith()` method's job. For more details and how they interact see example implementation:
- - [parent component](src/app/party-form/party-form.component.ts) 
- - [child form](src/app/person-contact/person-contact.component.ts) 
+ - [parent component](src/app/party-form/party-form.component.ts)
+ - [child form](src/app/person-contact/person-contact.component.ts)
  - [control value accessor connector](src/app/shared/control-value-accessor-connector.ts)
 
 ## Limitations

--- a/projects/forms/package-lock.json
+++ b/projects/forms/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "ngx-forms-typed",
+  "version": "1.0.8",
+  "lockfileVersion": 1
+}

--- a/projects/forms/package.json
+++ b/projects/forms/package.json
@@ -22,5 +22,16 @@
     "@angular/forms": ">=2.0.0",
     "typescript": ">=2.8.0"
   },
-  "keywords": ["angular", "forms", "form", "reactive-forms", "reactive forms", "angular 2", "typed form", "form typed", "typed forms", "forms typed"]
+  "keywords": [
+    "angular",
+    "forms",
+    "form",
+    "reactive-forms",
+    "reactive forms",
+    "angular 2",
+    "typed form",
+    "form typed",
+    "typed forms",
+    "forms typed"
+  ]
 }

--- a/projects/forms/src/lib/forms-typed.tests.ts
+++ b/projects/forms/src/lib/forms-typed.tests.ts
@@ -127,4 +127,11 @@ tags.push(typedFormControl(1));
 // patch value works with ❌ exception of 1 - not a string
 tags.patchValue(['1', '2', '3', 1]);
 
+// typed Form group Keys
+const tg = typedFormGroup<Model>({
+  name: typedFormControl(),
+  email: typedFormControl()
+})
+
+tg.keys.email
 

--- a/projects/forms/src/lib/forms-typed.tests.ts
+++ b/projects/forms/src/lib/forms-typed.tests.ts
@@ -28,7 +28,7 @@ export interface Model1 {
 
 // values in a typed form control are stronlgy typed
 const f = typedFormGroup<Model>({ name: new FormControl(), email: new FormControl() });
-f.valueChanges.subscribe(v => console.log(v));
+f.valueChanges.subscribe((v) => console.log(v));
 // controls are strongly typed too
 console.log(f.controls.email);
 f.setControl('name', typedFormControl());
@@ -36,12 +36,12 @@ f.setControl('name', typedFormControl());
 // vs standard form group are - neither controls nor values are typed
 const f1 = new FormGroup({ t: new FormControl() });
 console.log(f1.controls.any.value); // will break runtime
-f1.valueChanges.subscribe(v => console.log(v)); // v is not strongly typed
+f1.valueChanges.subscribe((v) => console.log(v)); // v is not strongly typed
 
 // form group with both controls and form arrays - strongly typed
 const f2 = typedFormGroup<Model1, TypedControlsIn<Model1, never, 'names'>>({
   names: typedFormArray([]),
-  email: typedFormControl()
+  email: typedFormControl(),
 });
 console.log(f2.controls.email);
 console.log(f2.controls.names.setControl(0, typedFormControl('')));
@@ -59,7 +59,7 @@ f3.setControl('email', typedFormControl());
 const f4 = typedFormGroup<Model1, TypedControlsIn<Model1, never, 'names'>>({
   names: typedFormArray([]),
   // ❌ should break
-  email: typedFormGroup<string>('test') // we disallow form group for simple types and null
+  email: typedFormGroup<string>('test'), // we disallow form group for simple types and null
 });
 f4.reset({ names: { value: [''], disabled: true }, email: '' });
 
@@ -82,9 +82,7 @@ const person = typedFormGroup<Person>({ name: typedFormControl(), address: typed
 const address = typedFormGroup<Address>({ postCode: typedFormControl(), line: typedFormControl() });
 
 // address each control in dot-chain type of API
-forEachControlIn(address)
-  .addValidatorsTo(person)
-  .markAsTouchedSimultaneouslyWith(person);
+forEachControlIn(address).addValidatorsTo(person).markAsTouchedSimultaneouslyWith(person);
 
 // AbstractControlOptions in form control
 typedFormControl('', { updateOn: 'blur' }, (v) => Promise.resolve(null));
@@ -100,11 +98,14 @@ typedFormControl('value', {
 });
 
 // AbstractControlOptions in form group
-typedFormGroup<{m: string}>({m: typedFormControl()}, {
-  updateOn: 'blur',
-  validators: (v) => null,
-  asyncValidators: [(v) => Promise.resolve(null), (v) => Promise.resolve({ e: 'error' })],
-});
+typedFormGroup<{ m: string }>(
+  { m: typedFormControl() },
+  {
+    updateOn: 'blur',
+    validators: (v) => null,
+    asyncValidators: [(v) => Promise.resolve(null), (v) => Promise.resolve({ e: 'error' })],
+  }
+);
 
 // AbstractControlOptions in form array
 typedFormArray<string[]>([typedFormControl()], {
@@ -112,5 +113,18 @@ typedFormArray<string[]>([typedFormControl()], {
   validators: (v) => null,
   asyncValidators: [(v) => Promise.resolve(null), (v) => Promise.resolve({ e: 'error' })],
 });
-// allow disabled setValue state
-f.controls.email.setValue({ disabled: true, value: 'string' });
+
+// typed form array with the single type only
+const tags = typedFormArray<string>([
+  typedFormControl('javascript'),
+  typedFormControl('typescript'),
+  typedFormControl('strong types'),
+  typedFormControl('strong code'),
+]);
+
+// typed form array push ❌ breaks because expecting string
+tags.push(typedFormControl(1));
+// patch value works with ❌ exception of 1 - not a string
+tags.patchValue(['1', '2', '3', 1]);
+
+

--- a/projects/forms/src/lib/forms-typed.tests.ts
+++ b/projects/forms/src/lib/forms-typed.tests.ts
@@ -1,59 +1,73 @@
-
 // tests
 
 import { FormControl, FormGroup } from '@angular/forms';
-import { TypedControlsIn, typedFormArray, typedFormControl, TypedFormControl, typedFormGroup, TypedFormGroup } from './forms-typed';
+import {
+  TypedControlsIn,
+  typedFormArray,
+  typedFormControl,
+  TypedFormControl,
+  typedFormGroup,
+  TypedFormGroup,
+} from './forms-typed';
 import { forEachControlIn } from './forms-util';
-
 
 export interface Model {
   name: string;
   email: string;
 }
 
-
 const form = typedFormGroup({ email: new FormControl(), name: new FormControl() }) as TypedFormGroup<Model>;
 console.log(form.controls.email);
-form.valueChanges.subscribe(v => console.log(v));
-form.statusChanges.subscribe(s => console.log(s));
-
+form.valueChanges.subscribe((v) => console.log(v));
+form.statusChanges.subscribe((s) => console.log(s));
 
 export interface Model1 {
   names: string[];
   email: string;
 }
 
+// values in a typed form control are stronlgy typed
 const f = typedFormGroup<Model>({ name: new FormControl(), email: new FormControl() });
 f.valueChanges.subscribe(v => console.log(v));
+// controls are strongly typed too
 console.log(f.controls.email);
 f.setControl('name', typedFormControl());
 
+// vs standard form group are - neither controls nor values are typed
 const f1 = new FormGroup({ t: new FormControl() });
 console.log(f1.controls.any.value); // will break runtime
 f1.valueChanges.subscribe(v => console.log(v)); // v is not strongly typed
 
-
+// form group with both controls and form arrays - strongly typed
 const f2 = typedFormGroup<Model1, TypedControlsIn<Model1, never, 'names'>>({
   names: typedFormArray([]),
   email: typedFormControl()
 });
-console.log(f2.controls); // controls are loosely typed - one of form control or group
+console.log(f2.controls.email);
+console.log(f2.controls.names.setControl(0, typedFormControl('')));
+const firstName = f2.controls.names.at(0);
 
+// controls strongly typed
 const f3 = typedFormGroup<Model, { name: TypedFormControl<string>; email: TypedFormControl<string> }>({
   name: typedFormControl(),
-  email: typedFormControl()
+  email: typedFormControl(),
 });
 console.log(f3.controls); // controls are strongly typed - know exactly what type of control for which key in your model
 f3.setControl('email', typedFormControl());
 
+// do not allow a form group for base types - string/number/etc.
 const f4 = typedFormGroup<Model1, TypedControlsIn<Model1, never, 'names'>>({
   names: typedFormArray([]),
+  // ❌ should break
   email: typedFormGroup<string>('test') // we disallow form group for simple types and null
 });
 f4.reset({ names: { value: [''], disabled: true }, email: '' });
-f4.reset({ names: [''] }, { emitEvent: true });
 
-
+// strong types for method options
+f4.reset(
+  { names: [''] },
+  { emitEvent: true, onlySelf: false, emitModelToViewChange: true, emitViewToModelChange: false }
+);
 
 interface Person {
   name: string;
@@ -64,10 +78,39 @@ interface Address {
   line: string;
 }
 
-
 const person = typedFormGroup<Person>({ name: typedFormControl(), address: typedFormControl() });
 const address = typedFormGroup<Address>({ postCode: typedFormControl(), line: typedFormControl() });
 
+// address each control in dot-chain type of API
 forEachControlIn(address)
   .addValidatorsTo(person)
   .markAsTouchedSimultaneouslyWith(person);
+
+// AbstractControlOptions in form control
+typedFormControl('', { updateOn: 'blur' }, (v) => Promise.resolve(null));
+typedFormControl('value', {
+  updateOn: 'blur',
+  validators: [(v) => null, (v) => ({ error: 'true' })],
+  asyncValidators: (v) => Promise.resolve(null),
+});
+typedFormControl('value', {
+  updateOn: 'blur',
+  validators: (v) => null,
+  asyncValidators: [(v) => Promise.resolve(null), (v) => Promise.resolve({ e: 'error' })],
+});
+
+// AbstractControlOptions in form group
+typedFormGroup<{m: string}>({m: typedFormControl()}, {
+  updateOn: 'blur',
+  validators: (v) => null,
+  asyncValidators: [(v) => Promise.resolve(null), (v) => Promise.resolve({ e: 'error' })],
+});
+
+// AbstractControlOptions in form array
+typedFormArray<string[]>([typedFormControl()], {
+  updateOn: 'blur',
+  validators: (v) => null,
+  asyncValidators: [(v) => Promise.resolve(null), (v) => Promise.resolve({ e: 'error' })],
+});
+// allow disabled setValue state
+f.controls.email.setValue({ disabled: true, value: 'string' });

--- a/projects/forms/src/lib/forms-typed.ts
+++ b/projects/forms/src/lib/forms-typed.ts
@@ -5,10 +5,14 @@ import { Observable } from 'rxjs';
  * Type encapsulating the Angular Form options:
  * `emitEvent` - do we emit event;
  * `onlySelf` - do we bubble up to parent
+ * `emitModelToViewChange` - When true or not supplied (the default), each change triggers an onChange event to update the view.
+ * `emitViewToModelChange` - When true or not supplied (the default), each change triggers an ngModelChange event to update the model.
  */
 export interface FormEventOptions {
   emitEvent?: boolean;
   onlySelf?: boolean;
+  emitModelToViewChange?: boolean;
+  emitViewToModelChange?: boolean;
 }
 
 /**

--- a/projects/forms/src/lib/forms-typed.ts
+++ b/projects/forms/src/lib/forms-typed.ts
@@ -91,7 +91,7 @@ export interface TypedFormArray<K extends Array<T> = any[], T = any> extends For
  * c.patchValue(['s']) // expects string[]
  * c.patchValue(1) //  COMPILE TIME! type error!
  */
-export function typedFormArray<K extends Array<T> = any[], T = any>(
+export function typedFormArray<T = any, K extends Array<T> = T[]>(
   controls: Array<TypedFormControl<T>>,
   validatorOrOptions?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null,
   asyncValidators?: AsyncValidatorFn | AsyncValidatorFn[] | null

--- a/projects/forms/src/lib/forms-typed.ts
+++ b/projects/forms/src/lib/forms-typed.ts
@@ -108,6 +108,7 @@ export type Controls<K> =
   };
 
 
+// tslint:disable-next-line:ban-types
 type NonGroup = string | number | boolean | Function | null | undefined | never;
 /**
  * This is a strongly typed thin wrapper type around `FormGroup`.
@@ -123,12 +124,14 @@ export interface TypedFormGroup<K, C extends Controls<K> = TypedControlsIn<K>> e
   setControl: <T extends keyof C>(name: T extends string ? T : never, control: C[T]) => void;
   reset: (value?: ResetValue<K>, options?: FormEventOptions) => void;
 }
-export function typedFormGroup<K, C extends Controls<K> = TypedControlsIn<K>>(
+export function typedFormGroup<K, C extends Controls<K> = TypedControlsIn<K>, Key extends keyof K = keyof K>(
   controls: K extends NonGroup ? never : C,
   validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null,
   asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null
-): TypedFormGroup<K, C> {
-  return new FormGroup(controls, validatorOrOpts, asyncValidator) as any;
+): TypedFormGroup<K, C> & { keys: Record<Key, string> } {
+  const f = new FormGroup(controls, validatorOrOpts, asyncValidator) as any;
+  f.keys = Object.keys(controls).map((k) => ({ [k]: k }));
+  return f;
 }
 
 /**

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,10 +1,9 @@
-.stand-alone-demo {
-  min-width: 150px;
-  max-width: 500px;
-  display: block;
-  margin: 0 auto;
-}
 
 mat-divider {
   margin: 20px 100px;
 }
+
+nav {
+  margin: 12px ;
+}
+

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,15 +1,9 @@
-<fty-party-form></fty-party-form>
-
-<mat-divider></mat-divider>
-
-<div class="stand-alone-demo">
-  Stand alone using ngModel
-  <fty-person-contact
-    [(ngModel)]="person"
-    #controlDirective="ngModel"
-  ></fty-person-contact>
-  <show-form-control
-    [control]="controlDirective.control"
-    name="person"
-  ></show-form-control>
-</div>
+<nav>
+  <mat-card>
+    <button mat-button routerLink="party">Party (FormGroup demo)</button>
+    <button mat-button routerLink="tags">Tags list (FormArray demo)</button>
+    <button mat-button routerLink="ngmodel">Person (NgModel demo)</button>
+    <button mat-button routerLink="people">People (FormArray of Person Form Groups)</button>
+  </mat-card>
+</nav>
+<router-outlet></router-outlet>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -8,5 +8,4 @@ import { PersonContact } from './person-contact/person-contact.model';
 })
 export class AppComponent {
   title = 'forms-typed';
-  person: PersonContact;
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,25 +1,37 @@
-import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
-
-import { AppComponent } from './app.component';
-import { PersonContactComponent } from './person-contact/person-contact.component';
-import { PartyFormComponent } from './party-form/party-form.component';
-import { EventFormComponent } from './event-form/event-form.component';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatCommonModule, MatNativeDateModule } from '@angular/material/core';
-import { MatInputModule } from '@angular/material/input';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatCommonModule, MatNativeDateModule } from '@angular/material/core';
 import { MatDatepickerModule } from '@angular/material/datepicker';
-import { ShowFormControlModule } from 'show-form-control';
-import { MatIconModule } from '@angular/material/icon';
 import { MatDividerModule } from '@angular/material/divider';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { RouterModule } from '@angular/router';
+import { ShowFormControlModule } from 'show-form-control';
 import { environment } from 'src/environments/environment';
+import { AppComponent } from './app.component';
+import { EventFormComponent } from './event-form/event-form.component';
+import { NgModelDemoComponent } from './ng-model-demo/ng-model-demo.component';
+import { PartyFormComponent } from './party-form/party-form.component';
+import { PersonContactComponent } from './person-contact/person-contact.component';
+import { TagsListComponent } from './tags-list/tags-list.component';
+import { PeopleComponent } from './people/people.component';
 
 @NgModule({
-  declarations: [AppComponent, PersonContactComponent, PartyFormComponent, EventFormComponent],
+  declarations: [
+    AppComponent,
+    PersonContactComponent,
+    PartyFormComponent,
+    EventFormComponent,
+    TagsListComponent,
+    NgModelDemoComponent,
+    PeopleComponent,
+  ],
   imports: [
     BrowserModule,
     ReactiveFormsModule,
@@ -34,9 +46,32 @@ import { environment } from 'src/environments/environment';
     MatIconModule,
     MatDividerModule,
     MatProgressSpinnerModule,
-    FormsModule
+    FormsModule,
+    RouterModule.forRoot([
+      {
+        path: 'party',
+        component: PartyFormComponent,
+      },
+      {
+        path: 'ngmodel',
+        component: NgModelDemoComponent,
+      },
+      {
+        path: 'tags',
+        component: TagsListComponent,
+      },
+      {
+        path: 'people',
+        component: PeopleComponent,
+      },
+      {
+        path: '**',
+        redirectTo: 'party',
+      },
+    ]),
+    MatCardModule,
   ],
   providers: [],
-  bootstrap: [AppComponent]
+  bootstrap: [AppComponent],
 })
-export class AppModule { }
+export class AppModule {}

--- a/src/app/ng-model-demo/ng-model-demo.component.css
+++ b/src/app/ng-model-demo/ng-model-demo.component.css
@@ -1,0 +1,6 @@
+.stand-alone-demo {
+  min-width: 150px;
+  max-width: 500px;
+  display: block;
+  margin: 0 auto;
+}

--- a/src/app/ng-model-demo/ng-model-demo.component.html
+++ b/src/app/ng-model-demo/ng-model-demo.component.html
@@ -1,0 +1,12 @@
+
+<div class="stand-alone-demo">
+  Stand alone using ngModel
+  <fty-person-contact
+    [(ngModel)]="person"
+    #controlDirective="ngModel"
+  ></fty-person-contact>
+  <show-form-control
+    [control]="controlDirective.control"
+    name="person"
+  ></show-form-control>
+</div>

--- a/src/app/ng-model-demo/ng-model-demo.component.spec.ts
+++ b/src/app/ng-model-demo/ng-model-demo.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NgModelDemoComponent } from './ng-model-demo.component';
+
+describe('NgModelDemoComponent', () => {
+  let component: NgModelDemoComponent;
+  let fixture: ComponentFixture<NgModelDemoComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ NgModelDemoComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NgModelDemoComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/ng-model-demo/ng-model-demo.component.ts
+++ b/src/app/ng-model-demo/ng-model-demo.component.ts
@@ -1,0 +1,17 @@
+import { Component, OnInit } from '@angular/core';
+import { PersonContact } from '../person-contact/person-contact.model';
+
+@Component({
+  selector: 'fty-ng-model-demo',
+  templateUrl: './ng-model-demo.component.html',
+  styleUrls: ['./ng-model-demo.component.css']
+})
+export class NgModelDemoComponent implements OnInit {
+  person: PersonContact;
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/party-form/party-form.component.css
+++ b/src/app/party-form/party-form.component.css
@@ -2,15 +2,6 @@
   text-align: center;
 }
 
-.fieldset {
-  min-width: 150px;
-  max-width: 500px;
-  display: block;
-  margin: 0 auto;
-  box-shadow: 0 2px 1px -1px rgba(0,0,0,.2), 0 1px 1px 0 rgba(0,0,0,.14), 0 1px 3px 0 rgba(0,0,0,.12);
-  border: none;
-  border-radius: 5px;
-}
 
 .add-button {
   margin-right: 50px;

--- a/src/app/party-form/party-form.component.html
+++ b/src/app/party-form/party-form.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="form" (ngSubmit)="onPartyFormSubmit()" class="party-form">
   <fieldset class="fieldset">
     <legend>Event</legend>
-    <fty-event-form formControlName="event"></fty-event-form>
+    <fty-event-form [formControlName]="form.keys.event"></fty-event-form>
     <button type="button" mat-fab color="primary" (click)="toggleEvent()" class="add-button">
       {{ form.controls.event.enabled ? 'Disable' : 'Enable' }}
     </button>

--- a/src/app/party-form/party-form.component.html
+++ b/src/app/party-form/party-form.component.html
@@ -2,6 +2,9 @@
   <fieldset class="fieldset">
     <legend>Event</legend>
     <fty-event-form formControlName="event"></fty-event-form>
+    <button type="button" mat-fab color="primary" (click)="toggleEvent()" class="add-button">
+      {{ form.controls.event.enabled ? 'Disable' : 'Enable' }}
+    </button>
   </fieldset>
   <fieldset class="fieldset">
     <legend>Invited</legend>

--- a/src/app/party-form/party-form.component.ts
+++ b/src/app/party-form/party-form.component.ts
@@ -24,6 +24,7 @@ export class PartyFormComponent implements OnInit {
   });
 
   get invitees() {
+    this.form.keys.event;
     return this.form.controls.invitees;
   }
 

--- a/src/app/party-form/party-form.component.ts
+++ b/src/app/party-form/party-form.component.ts
@@ -5,7 +5,7 @@ import {
   typedFormControl,
   typedFormArray,
   TypedFormArray,
-  TypedArraysIn
+  TypedArraysIn,
 } from 'forms';
 import { PartyForm } from './party-form.model';
 import { take } from 'rxjs/operators';
@@ -15,12 +15,12 @@ import { PersonContact } from '../person-contact/person-contact.model';
 @Component({
   selector: 'fty-party-form',
   templateUrl: './party-form.component.html',
-  styleUrls: ['./party-form.component.css']
+  styleUrls: ['./party-form.component.css'],
 })
 export class PartyFormComponent implements OnInit {
   form = typedFormGroup<PartyForm, TypedArraysIn<PartyForm, 'invitees'>>({
-    event: typedFormControl(eventDefault()),
-    invitees: typedFormArray([typedFormControl()])
+    event: typedFormControl({ disabled: true, value: eventDefault() }),
+    invitees: typedFormArray([typedFormControl()]),
   });
 
   get invitees() {
@@ -66,5 +66,10 @@ export class PartyFormComponent implements OnInit {
     if (Array.isArray(invitees.controls) && invitees.controls.length > 0) {
       invitees.removeAt(invitees.controls.length - 1);
     }
+  }
+
+  toggleEvent() {
+    const e = this.form.controls.event;
+    e.enabled ? e.disable() : e.enable();
   }
 }

--- a/src/app/people/people.component.html
+++ b/src/app/people/people.component.html
@@ -1,0 +1,18 @@
+<div class="centered-content">
+  <form (ngSubmit)="onSubmit()">
+    <fieldset *ngFor="let person of people?.controls; index as i" style="position: relative;" class="fieldset">
+      <legend>{{person?.value?.name || i}}</legend>
+      <fty-person-contact  [formControl]="person"></fty-person-contact>
+      <button mat-button color="warn" (click)="removeAt(i)" style="position:absolute;top:5px;right:5px">✖</button>
+    </fieldset>
+    <button mat-button type="button" (click)="add()">Add person</button>
+    <hr />
+    <button mat-button  color="primary" type="submit">Done</button>
+    <button mat-button  color="warn" type="reset">Reset</button>
+  </form>
+</div>
+
+<show-form-control
+    [control]="people"
+    name="people"
+  ></show-form-control>

--- a/src/app/people/people.component.spec.ts
+++ b/src/app/people/people.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PeopleComponent } from './people.component';
+
+describe('PeopleComponent', () => {
+  let component: PeopleComponent;
+  let fixture: ComponentFixture<PeopleComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ PeopleComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PeopleComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/people/people.component.ts
+++ b/src/app/people/people.component.ts
@@ -1,0 +1,29 @@
+import { Component, OnInit } from '@angular/core';
+import { typedFormArray, typedFormControl } from 'forms';
+import { PersonContact } from '../person-contact/person-contact.model';
+
+@Component({
+  selector: 'fty-people',
+  templateUrl: './people.component.html',
+  styleUrls: ['./people.component.css']
+})
+export class PeopleComponent implements OnInit {
+  people = typedFormArray<PersonContact>([typedFormControl()]);
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+  add() {
+    this.people.push(typedFormControl());
+  }
+
+  removeAt(i: number) {
+    if (this.people.at(i) != null) {
+      this.people.removeAt(i);
+    }
+  }
+  onSubmit() {
+    this.people = typedFormArray<PersonContact>([typedFormControl({name: '', email: ''})]);
+  }
+}

--- a/src/app/tags-list/tags-list.component.css
+++ b/src/app/tags-list/tags-list.component.css
@@ -1,0 +1,6 @@
+form {
+  min-width: 150px;
+  max-width: 500px;
+  display: block;
+  margin: 0 auto;
+}

--- a/src/app/tags-list/tags-list.component.html
+++ b/src/app/tags-list/tags-list.component.html
@@ -1,0 +1,15 @@
+<form (ngSubmit)="onSubmit()" class="centered-content">
+  <div *ngFor="let tag of form.controls;index as i">
+    <mat-form-field>
+      <mat-label>Tag ({{i + 1}})</mat-label>
+      <input matInput [formControl]="tag" />
+    </mat-form-field>
+    <button type="button" mat-button color="warn" (click)="removeAt(i)">❌</button>
+  </div>
+  <button mat-button type="button" (click)="add()">Add tag</button>
+  <hr />
+  <button mat-button  color="primary" type="submit">Done</button>
+  <button mat-button  color="warn" type="reset">Reset</button>
+</form>
+
+<show-form-control [control]="form"></show-form-control>

--- a/src/app/tags-list/tags-list.component.spec.ts
+++ b/src/app/tags-list/tags-list.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TagsListComponent } from './tags-list.component';
+
+describe('TagsListComponent', () => {
+  let component: TagsListComponent;
+  let fixture: ComponentFixture<TagsListComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ TagsListComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TagsListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/tags-list/tags-list.component.ts
+++ b/src/app/tags-list/tags-list.component.ts
@@ -1,0 +1,33 @@
+import { Component, OnInit } from '@angular/core';
+import { typedFormArray, typedFormControl } from 'forms';
+
+interface Tag {
+  name: string;
+  value: string;
+}
+
+@Component({
+  selector: 'fty-tags-list',
+  templateUrl: './tags-list.component.html',
+  styleUrls: ['./tags-list.component.css'],
+})
+export class TagsListComponent implements OnInit {
+  form = typedFormArray<string>([]);
+
+  constructor() {}
+  /*  */
+  ngOnInit(): void {}
+
+  add() {
+    this.form.push(typedFormControl(''));
+  }
+
+  removeAt(i: number) {
+    if (this.form.at(i) != null) {
+      this.form.removeAt(i);
+    }
+  }
+  onSubmit() {
+    this.form = typedFormArray<string>([]);
+  }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -2,3 +2,20 @@
 
 html, body { height: 100%; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
+
+.fieldset {
+  min-width: 150px;
+  max-width: 500px;
+  display: block;
+  margin: 0 auto;
+  box-shadow: 0 2px 1px -1px rgba(0,0,0,.2), 0 1px 1px 0 rgba(0,0,0,.14), 0 1px 3px 0 rgba(0,0,0,.12);
+  border: none;
+  border-radius: 5px;
+}
+
+.centered-content {
+    min-width: 150px;
+    max-width: 500px;
+    display: block;
+    margin: 0 auto;
+}


### PR DESCRIPTION

## feat(form group): add keys
- keys will hold the keys of the group in a type-safe manner for access example:
    - `<input [formControlName]=form.keys.email" />`
- add examples in the readme

## feat(form event option): modelToView and viceversa 
- add the  model to view and view to model
```ts
export interface FormEventOptions {
    //...
    emitModelToViewChange?: boolean;
    emitViewToModelChange?: boolean;
}
```
- add some more type 'tests'
## chore(semantic): use branch rc/
## chore(semantic): add rc/** to semantic release config
## chore(docs): add vscode color
## fix(typed array): order type arguments …

closes #47
- now `typedFormArray<string>`
- was  `typedFormArray<string[], string>`
for the same thing
  - in the "was" case it the second argument was skipped it was inferred as `any`
 - add a TEST step - build the example project which uses the full spectrum of functionality
 - add 2 FormArray examples - string one and object one (PersonContact)
