### PR TITLE
fix: support arrays of validators and async

### DIFF
--- a/.github/workflows/test-forms-typed.yml
+++ b/.github/workflows/test-forms-typed.yml
@@ -17,5 +17,5 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: build lib
-        run: npx ng build forms && npx ng build show-form-control && npx ng build
+        run: npm run build:all
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,11 +2,9 @@
 
 Hi, and thanks for your interest!
 
-There are 2 libraries living in this repo:
+There are:
 - `ngx-forms-typed` - /projects/forms
-- `ngx-show-form-control` - /projects/show-form-control
-
-And there's also an example app that lives in /src folder.
+- `/src` - an example app showcasing usage of the lib
 
 ## Setup
 We are using a couple of libraries to setup our process of contributing:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "forms-typed-examples",
   "version": "0.0.0-development",
+  "license": "MIT",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/projects/forms/CHANGELOG.md
+++ b/projects/forms/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [1.1.2] - 2021-07-07
+
+### Fixed
+-   missing support for `ValidatorFn[]` and `AsyncValidatorFn[]` for `typedFormControl`
 
 ## [1.1.1] - 2021-06-05
 ### Fixed

--- a/projects/forms/src/lib/forms-typed.tests.ts
+++ b/projects/forms/src/lib/forms-typed.tests.ts
@@ -131,7 +131,12 @@ tags.patchValue(['1', '2', '3', 1]);
 const tg = typedFormGroup<Model>({
   name: typedFormControl(),
   email: typedFormControl()
-})
+});
 
-tg.keys.email
+const emailControlKey = tg.keys.email;
 
+
+
+
+// support validator function array in typedFormControl
+const validators = typedFormControl<string>('', [a => null, () => ({})], [async () => null, async () => Promise.resolve({})]);

--- a/projects/forms/src/lib/forms-typed.ts
+++ b/projects/forms/src/lib/forms-typed.ts
@@ -59,8 +59,8 @@ export interface TypedFormControl<K> extends FormControl, AbstractControl {
  */
 export function typedFormControl<T>(
   v?: T | { value: T; disabled: boolean },
-  validatorsOrOptions?: ValidatorFn | AbstractControlOptions,
-  asyncValidators?: AsyncValidatorFn
+  validatorsOrOptions?: ValidatorFn | ValidatorFn[] | AbstractControlOptions,
+  asyncValidators?: AsyncValidatorFn | AsyncValidatorFn[]
 ): TypedFormControl<T> {
   return new FormControl(v, validatorsOrOptions, asyncValidators);
 }


### PR DESCRIPTION
- add the support for both `ValidatorFn[]` and `AsyncValidatorFn[]` for `typedFormControl`
- add licence
- fix contributors guide

closes #53 #38  